### PR TITLE
feat: add mjs mime type to the nginx config 

### DIFF
--- a/overlay/etc/nginx/nginx.conf
+++ b/overlay/etc/nginx/nginx.conf
@@ -7,6 +7,10 @@ events {
 
 http {
     include       /etc/nginx/mime.types;
+    types 
+    {
+        application/javascript mjs;
+    }
     default_type  application/octet-stream;
 
     sendfile           on;


### PR DESCRIPTION
# Description

OwnCloud Web switched the file extension from `*.js` to `*.mjs`

mjs files need to be explicitly configured in the nginx config.

https://semisignal.com/serving-mjs-files-with-nginx/