### PR TITLE
Fix public link resolving on owncloud web

### DIFF
--- a/overlay/etc/nginx/vhost.conf
+++ b/overlay/etc/nginx/vhost.conf
@@ -5,6 +5,11 @@ server {
     location / {
         root   /var/lib/nginx/html;
         index  index.html index.htm;
+        # needed for SPA's
+        try_files $uri $uri/ /index.html;
+        # Enable sub_filter to inject the base tag into index.html
+        sub_filter '<head>' '<head><base href="/">';
+        sub_filter_once on;
     }
 
     # redirect server error pages to the static page /50x.html


### PR DESCRIPTION
# Description

OwnCloud Web was not able to resolve links.

This also fixes the `#` in the URL